### PR TITLE
bower json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,13 @@
+{
+  "name": "of.uploader",
+  "version": "1.0.0",
+  "description": "loading files to print-box with percentage progress report",
+  "homepage": "https://github.com/oneflow/of.uploader",
+  "main": "src/index.js",
+  "authors": [
+    "Nigel Watson"
+  ],
+  "ignore": [
+    "/test/*"
+  ]
+}


### PR DESCRIPTION
We use 'gulp-main-bower-files'  (https://www.npmjs.com/package/gulp-main-bower-files) to concat and connect bower modules to app. 

This read bower.json, iterate through dependencies and returns an array of files defined in the main property of the packages bower.json.

currently, this package have not  it's own bower.json file, and this file is generating automaticaly after 'bower install oneflow/of.uploader'  command. In this generated bower.json the 'main' filed is not present. there is a reason why this module is not adding in 'vendor.js' file after gulp build.

this pr is adding required bower.json file and make possibly the using this module in our apps by bower manager.
