### PR TITLE
Fix: clear queue method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -234,6 +234,7 @@ angular.module('of.uploader').factory('ofUploaderQueue', ['$q', '$http', 'FileUp
 
 	function clearQueue() {
 		queue = [];
+		uploader.queue = queue;
 	}
 
 	function uploadAll() {


### PR DESCRIPTION
clearqueue function was not working properly as it was clear queue array and it broke link from instance queue property to queue array.

[this required to fix this](https://github.com/Oneflow/task-tracker/issues/2256)

_once this will merged to development, development will should be merged into master to get this change on easy submit and box_